### PR TITLE
Add versioning scripts

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -2,6 +2,11 @@
   "name": "api",
   "version": "0.0.0",
   "private": true,
+  "scripts": {
+    "release:major": "yarn version --major",
+    "release:minor": "yarn version --minor",
+    "release:patch": "yarn version --patch"
+  },
   "dependencies": {
     "@redwoodjs/api": "^0.35.2",
     "cuid": "^2.1.8",

--- a/api/package.json
+++ b/api/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "release:major": "yarn version --major",
-    "release:minor": "yarn version --minor",
-    "release:patch": "yarn version --patch"
+    "version:major": "yarn version --no-git-tag-version --major",
+    "version:minor": "yarn version --no-git-tag-version --minor",
+    "version:patch": "yarn version --no-git-tag-version --patch"
   },
   "dependencies": {
     "@redwoodjs/api": "^0.35.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
       "packages/*"
     ]
   },
+  "scripts": {
+    "release:major": "yarn workspaces run release:major",
+    "release:minor": "yarn workspaces run release:minor",
+    "release:patch": "yarn workspaces run release:patch"
+  },
   "devDependencies": {
     "@redwoodjs/core": "^0.35.2",
     "cuid": "^2.1.8",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "version": "0.0.0",
   "workspaces": {
     "packages": [
       "api",
@@ -8,9 +9,10 @@
     ]
   },
   "scripts": {
-    "release:major": "yarn workspaces run release:major",
-    "release:minor": "yarn workspaces run release:minor",
-    "release:patch": "yarn workspaces run release:patch"
+    "version:major": "yarn workspaces run version:major && yarn version --no-git-tag-version --major",
+    "version:minor": "yarn workspaces run version:minor && yarn version --no-git-tag-version --minor",
+    "version:patch": "yarn workspaces run version:patch && yarn version --no-git-tag-version --patch",
+    "postversion": "git add . && git commit -m $npm_package_version && git tag $npm_package_version -am $npm_package_version"
   },
   "devDependencies": {
     "@redwoodjs/core": "^0.35.2",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,11 @@
       "not IE_Mob 11"
     ]
   },
+  "scripts": {
+    "release:major": "yarn version --major",
+    "release:minor": "yarn version --minor",
+    "release:patch": "yarn version --patch"
+  },
   "dependencies": {
     "@headlessui/react": "^1.3.0",
     "@octokit/core": "^3.5.1",

--- a/web/package.json
+++ b/web/package.json
@@ -13,9 +13,9 @@
     ]
   },
   "scripts": {
-    "release:major": "yarn version --major",
-    "release:minor": "yarn version --minor",
-    "release:patch": "yarn version --patch"
+    "version:major": "yarn version --no-git-tag-version --major",
+    "version:minor": "yarn version --no-git-tag-version --minor",
+    "version:patch": "yarn version --no-git-tag-version --patch"
   },
   "dependencies": {
     "@headlessui/react": "^1.3.0",

--- a/web/src/layouts/DefaultLayout/DefaultLayout.tsx
+++ b/web/src/layouts/DefaultLayout/DefaultLayout.tsx
@@ -16,6 +16,7 @@ import { FiUser, FiBookmark, FiSettings, FiLogOut } from 'react-icons/fi'
 import { VscGithubInverted } from 'react-icons/vsc'
 import LogoFull from 'src/lib/logo.svg'
 import LogoSmall from 'src/lib/logo-small.svg'
+import packageJson from '../../../package.json'
 import '@reach/skip-nav/styles.css'
 
 type DefaultLayoutProps = {
@@ -167,6 +168,14 @@ const DefaultLayout = ({ children }: DefaultLayoutProps) => {
                 </Link>
               ))}
             </nav>
+            <span className="mr-1">{' | '}</span>
+            <p>
+              <a
+                href={`https://github.com/devshare-me/devshare/releases/tag/v${packageJson.version}`}
+                target="_blank"
+                rel="noreferrer"
+              >{`v${packageJson.version}`}</a>
+            </p>
           </div>
         </footer>
       </div>


### PR DESCRIPTION
Add scripts that update the versioning for all workspaces.

## Options

- major: `yarn version:major`
- minor: `yarn version:minor`
- patch: `yarn version:patch`

## Functionality

The scripts run as follows:

1. Updates the version based on the option provided for each workspace
2. Updates the version of the main `package.json`
3. Commits the files with a version number and tag